### PR TITLE
fix: validate order keys and product IDs before expensive operations

### DIFF
--- a/backend/questionnaire/services.py
+++ b/backend/questionnaire/services.py
@@ -5,6 +5,7 @@ Business logic services for questionnaire operations.
 import asyncio
 import logging
 import uuid6
+from collections import Counter
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING
 from io import BytesIO
@@ -333,6 +334,22 @@ class QuestionnaireService:
 
             # Check for cancellation after question extraction
             self.async_tasks_service.check_cancellation(task_id)
+
+            # Validate order values before expensive answer generation
+            orders = [q.get("order") for q in extracted_questions_data]
+            missing = [i for i, o in enumerate(orders) if o is None]
+            if missing:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Questions at indices {missing} are missing an 'order' value",
+                )
+            order_counts = Counter(orders)
+            duplicates = {o for o, count in order_counts.items() if count > 1}
+            if duplicates:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Duplicate question order values detected: {duplicates}",
+                )
 
             questions_with_data = await self._generate_answers_for_questions(
                 extracted_questions_data, product_id, task_id, organization_id

--- a/backend/requirements/crud/services.py
+++ b/backend/requirements/crud/services.py
@@ -73,12 +73,7 @@ class RequirementService:
     async def create_requirement(
         self, requirement_data: models.RequirementCreate
     ) -> models.RequirementDto:
-        text_to_embed = _build_text_to_embed(
-            requirement_data.description, requirement_data.implementation_description
-        )
-        embedding = await self.external_ai_service.create_embeddings(text_to_embed)
-        requirement_data.embedding = embedding
-
+        # Validate product_id and generate key BEFORE expensive embedding call
         org_id = get_organization_id()
         row = self.product_repository.increment_and_get_product_key(
             requirement_data.product_id
@@ -88,8 +83,13 @@ class RequirementService:
                 status_code=400, detail="Invalid product_id for requirement creation"
             )
         current_number, product_key = row
-
         requirement_key = f"{product_key}-{current_number}"
+
+        text_to_embed = _build_text_to_embed(
+            requirement_data.description, requirement_data.implementation_description
+        )
+        embedding = await self.external_ai_service.create_embeddings(text_to_embed)
+        requirement_data.embedding = embedding
 
         return self.repository.create(
             requirement_data, organization_id=org_id, requirement_key=requirement_key
@@ -302,6 +302,9 @@ class RequirementService:
             # Check for cancellation before AI extraction
             self.async_tasks_service.check_cancellation(task_id)
 
+            # Validate product_id and generate document key BEFORE expensive AI extraction
+            document_key = self._generate_document_key(product_id)
+
             # Get existing requirement types for the organization
             existing_types = self.repository.get_distinct_types(organization_id)
 
@@ -317,9 +320,6 @@ class RequirementService:
 
             # Check for cancellation after AI extraction
             self.async_tasks_service.check_cancellation(task_id)
-
-            # Generate document key
-            document_key = self._generate_document_key(product_id)
 
             # Remove file extension from the filename for display purposes
             filename_without_extension = Path(file_name).stem


### PR DESCRIPTION
## Summary

- Move product ID validation and key generation before expensive embedding calls in requirement creation
- Move document key generation before costly AI extraction in document upload flow
- Add validation for missing and duplicate question order values before answer generation in questionnaire processing

## Related issue

Closes #9