### PR TITLE
feat(answering): limit source document search and total tool calls

### DIFF
--- a/backend/ai_framework/workflow/question/answering/agents/answer_agent.py
+++ b/backend/ai_framework/workflow/question/answering/agents/answer_agent.py
@@ -92,36 +92,43 @@ Example: "What is the OAuth2 token expiration time?"
 6. Answer: answer_type="n/a", explanation="The system's OAuth2 tokens expire after 30 minutes.", requirements_referenced=[REQ-AUTH-001], sources_referenced=[DOC-OAUTH-001 with section]
 """
 
-# Maximum number of semantic search calls allowed before disabling the tool
-MAX_SEARCH_CALLS = 3
-
-
-async def limit_search_tool(
+async def limit_tools(
     ctx: RunContext[AnsweringDeps],
     tool_defs: list[ToolDefinition],
 ) -> list[ToolDefinition] | None:
-    """Filter out search_requirements_semantic tool after MAX_SEARCH_CALLS.
+    """Dynamically filter tools based on usage limits.
 
     This callback is passed to the agent's prepare_tools parameter.
-    It dynamically disables the semantic search tool after the configured
-    number of calls to prevent excessive searching when no requirements exist.
+    It enforces three limits:
+    1. Total tool calls: strips ALL tools to force the agent to conclude
+    2. Semantic search calls: removes search_requirements_semantic
+    3. Source doc search calls: removes search_source_document
 
     Args:
-        ctx: The run context containing AnsweringDeps with search_count
+        ctx: The run context containing AnsweringDeps with counters
         tool_defs: List of available tool definitions
 
     Returns:
-        Filtered list of tool definitions, excluding search_requirements_semantic
-        if the search limit has been reached
+        Filtered list of tool definitions based on current usage limits
     """
-    if ctx.deps.search_count >= MAX_SEARCH_CALLS:
-        # Filter out the search tool, keep all others (get_requirement, get_source_documents, etc.)
-        return [
+    deps = ctx.deps
+    if deps.total_tool_call_count >= AnsweringDeps.MAX_TOTAL_TOOL_CALLS:
+        return []
+
+    filtered = tool_defs
+    if deps.search_count >= AnsweringDeps.MAX_SEARCH_CALLS:
+        filtered = [
             tool_def
-            for tool_def in tool_defs
+            for tool_def in filtered
             if tool_def.name != "search_requirements_semantic"
         ]
-    return tool_defs
+    if deps.source_doc_search_count >= AnsweringDeps.MAX_SOURCE_DOC_SEARCH_CALLS:
+        filtered = [
+            tool_def
+            for tool_def in filtered
+            if tool_def.name != "search_source_document"
+        ]
+    return filtered
 
 
 def create_answer_agent(
@@ -161,7 +168,7 @@ def create_answer_agent(
         system_prompt=FULL_ANSWER_SYSTEM_PROMPT,
         tools=tools,
         output_type=FullAnswerResult,
-        prepare_tools=limit_search_tool,
+        prepare_tools=limit_tools,
     )
 
     # Add validation if enabled

--- a/backend/ai_framework/workflow/question/answering/answering_deps.py
+++ b/backend/ai_framework/workflow/question/answering/answering_deps.py
@@ -30,7 +30,13 @@ class AnsweringDeps:
         organization_id: ID of the organization owning the question
         question_text: The actual question text to be answered
         search_count: Counter for tracking semantic search tool calls
+        source_doc_search_count: Counter for tracking source document search tool calls
+        total_tool_call_count: Counter for tracking all tool calls across all tools
     """
+
+    MAX_SEARCH_CALLS: int = 3
+    MAX_SOURCE_DOC_SEARCH_CALLS: int = 5
+    MAX_TOTAL_TOOL_CALLS: int = 40
 
     db_engine: Engine
     s3_service: S3Service
@@ -38,6 +44,8 @@ class AnsweringDeps:
     organization_id: str
     question_text: str
     search_count: int = 0
+    source_doc_search_count: int = 0
+    total_tool_call_count: int = 0
 
     def create_requirement_repository(self, session: Session) -> RequirementRepository:
         """Create a RequirementRepository instance for the given session.

--- a/backend/ai_framework/workflow/question/answering/requirement_tools.py
+++ b/backend/ai_framework/workflow/question/answering/requirement_tools.py
@@ -101,6 +101,7 @@ def create_search_requirements_semantic_tool() -> Callable[
         """
         # Increment search counter for tracking tool usage
         ctx.deps.search_count += 1
+        ctx.deps.total_tool_call_count += 1
 
         deps = ctx.deps
 
@@ -167,6 +168,8 @@ def create_get_requirement_tool() -> Callable[
         Returns:
             RequirementDetails object with full requirement information, or None if not found
         """
+        ctx.deps.total_tool_call_count += 1
+
         deps = ctx.deps
 
         # Create session and services with proper lifecycle management

--- a/backend/ai_framework/workflow/question/answering/source_document_tools.py
+++ b/backend/ai_framework/workflow/question/answering/source_document_tools.py
@@ -57,6 +57,8 @@ def create_get_source_documents_tool() -> Callable[
             List of SourceDocumentInfo objects with document_key and filename.
             Returns empty list if requirement doesn't exist or has no linked documents.
         """
+        ctx.deps.total_tool_call_count += 1
+
         deps = ctx.deps
 
         # Create session and services with proper lifecycle management
@@ -151,6 +153,9 @@ def create_search_source_document_tool() -> Callable[
         Raises:
             ValueError: If regex pattern is invalid
         """
+        ctx.deps.source_doc_search_count += 1
+        ctx.deps.total_tool_call_count += 1
+
         deps = ctx.deps
 
         # Step 1: Query database to resolve document_key to s3_object_key


### PR DESCRIPTION
## Summary

- Add per-tool call limits to the answering agent to prevent excessive tool usage
- Enforce max 5 source document search calls and max 40 total tool calls across all tools
- Move limit constants into `AnsweringDeps` and track counters (`source_doc_search_count`, `total_tool_call_count`) per tool invocation
- Rename `limit_search_tool` to `limit_tools` to reflect its broader scope

## Related issue

Closes #15