### PR TITLE
fix: annotate AnsweringDeps constants as ClassVar to fix dataclass field ordering

### DIFF
--- a/backend/ai_framework/workflow/question/answering/answering_deps.py
+++ b/backend/ai_framework/workflow/question/answering/answering_deps.py
@@ -6,7 +6,7 @@ and context for question answering agents.
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import ClassVar, TYPE_CHECKING
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from s3_service import S3Service
@@ -34,9 +34,9 @@ class AnsweringDeps:
         total_tool_call_count: Counter for tracking all tool calls across all tools
     """
 
-    MAX_SEARCH_CALLS: int = 3
-    MAX_SOURCE_DOC_SEARCH_CALLS: int = 5
-    MAX_TOTAL_TOOL_CALLS: int = 40
+    MAX_SEARCH_CALLS: ClassVar[int] = 3
+    MAX_SOURCE_DOC_SEARCH_CALLS: ClassVar[int] = 5
+    MAX_TOTAL_TOOL_CALLS: ClassVar[int] = 40
 
     db_engine: Engine
     s3_service: S3Service


### PR DESCRIPTION
## Summary

- Annotate `MAX_SEARCH_CALLS`, `MAX_SOURCE_DOC_SEARCH_CALLS`, and `MAX_TOTAL_TOOL_CALLS` as `ClassVar[int]` so Python's `@dataclass` decorator treats them as class-level constants instead of instance fields
- This fixes the `TypeError: non-default argument 'db_engine' follows default argument` crash introduced in #17

## Related issue

Closes #18