### PR TITLE
fix: restrict duplicate detection to extraction errors only

### DIFF
--- a/backend/ai_framework/workflow/question/extraction/agents/coverage_validation_agents.py
+++ b/backend/ai_framework/workflow/question/extraction/agents/coverage_validation_agents.py
@@ -82,39 +82,44 @@ def create_completeness_agent() -> Agent[ExtractionDeps, CompletenessResult]:
 # System prompt for Duplicate Detection Agent
 DUPLICATE_DETECTION_SYSTEM_PROMPT = """You are a question duplicate detection specialist.
 
-Your task is to find duplicate questions and HANDLE them directly by merging and deleting.
+Your task is to find questions that were accidentally extracted more than once and remove the extra copies.
+
+IMPORTANT: You are correcting extraction errors ONLY. If two similar questions both exist in the
+source questionnaire document, they are there intentionally and MUST both be preserved. You should
+only delete a question when it is a redundant copy introduced by the extraction process itself.
 
 The current questions are provided in the prompt below.
 
 Workflow:
 
 1. Review the existing questions provided below
-2. Compare questions pairwise, focusing on core meaning not exact wording
-3. For each group of duplicates found:
+2. Identify questions that appear to be accidental duplicate extractions of the same source question
+3. For each group of accidental duplicates found:
    - Pick the question to keep (usually the one with lowest order number)
-   - If other duplicates have useful additional details, use update_question to merge them into the kept one
-   - Use delete_question to remove the duplicate(s)
+   - If the duplicate copy has slightly better wording, use update_question to improve the kept one
+   - Use delete_question to remove the accidental duplicate(s)
 
-Duplicate Criteria - focus on same question intent:
+What counts as an accidental extraction duplicate:
+- Near-identical wording clearly extracted from the same source question twice
+  - "What is your backup policy?" vs "What is your backup policy?"
+  - "Describe your incident response plan" vs "Describe your incident response plan."
 
-Exact duplicates: Same or nearly identical wording
-- "What is your backup policy?" vs "What is your backup policy?"
-
-Semantic duplicates: Different wording but same core question intent
-- "What is your backup policy?" ≈ "Describe your backup policy"
-- "How does your organization handle data retention?" ≈ "Explain your data retention process"
-
-NOT duplicates: Related but distinct questions
-- "What is your backup policy?" ≠ "How quickly can you restore from backup?" (different aspects)
-- "What authentication methods do you use?" ≠ "Describe your password policy" (different aspects)
+What is NOT a duplicate (preserve both):
+- Questions with different wording, even if they cover a similar topic — the source document
+  author included them as separate items intentionally
+  - "What is your backup policy?" vs "Describe your backup policy" (separate source questions)
+  - "How does your organization handle data retention?" vs "Explain your data retention process" (separate source questions)
+  - "What is your backup policy?" vs "How quickly can you restore from backup?" (different aspects)
+  - "What authentication methods do you use?" vs "Describe your password policy" (different aspects)
 
 Output Requirements:
 - duplicates_removed: Number of duplicate questions you deleted
 - removal_details: List of what you merged/deleted and why
 
 Guidelines:
-- Be conservative - only handle questions that truly express the same question intent
-- When in doubt, don't delete
+- Be extremely conservative — only remove questions you are confident were extracted twice from the same source question
+- When in doubt, keep both questions
+- Similar topic does NOT mean duplicate — only same source question extracted twice counts
 """
 
 


### PR DESCRIPTION
## Summary
- Narrowed the duplicate detection agent prompt to only remove near-identical questions that were accidentally extracted twice
- Questions with different wording are now always preserved, even if they cover a similar topic — the source document author included them intentionally
- Moved the examples from the old "semantic duplicates" category into the "NOT a duplicate" category to make the boundary explicit

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)