### PR TITLE
feat: add provenance (supply chain verification) to workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-and-push:
@@ -59,6 +61,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
@@ -69,3 +72,9 @@ jobs:
           build-contexts: ${{ matrix.build_contexts }}
           cache-from: type=registry,ref=ghcr.io/rekwai/rekwai/${{ matrix.name }}:buildcache
           cache-to: type=registry,ref=ghcr.io/rekwai/rekwai/${{ matrix.name }}:buildcache,mode=max
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/rekwai/rekwai/${{ matrix.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
## Summary

The pipeline is already adding metadata (SLSA provenance attestation manifest & OCI image index) to the registry, so instead of disabling it make it usable so users can verify the authenticity of the built image.

## Related issue

#2 
