### PR TITLE
fix(docker): set project name in compose files

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,6 @@
 ---
+name: rekwai-dev
+
 services:
 
   backend:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,6 @@
 ---
+name: rekwai
+
 services:
 
   backend:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ You'll need an API key from one of the supported AI providers:
    echo "S3_ACCESS_KEY_ID=GK$(openssl rand -hex 12)" >> .env
    echo "S3_SECRET_ACCESS_KEY=$(openssl rand -hex 32)" >> .env
    echo "GARAGE_RPC_SECRET=$(openssl rand -hex 32)" >> .env
-   echo "GARAGE_ADMIN_TOKEN=$(openssl rand -hex 32)" >> .env
+   echo "GARAGE_ADMIN_TOKEN=$(openssl rand -base64 32)" >> .env
    echo "GARAGE_METRICS_TOKEN=$(openssl rand -base64 32)" >> .env
    ```
 5. **Configure your AI provider:**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,21 +26,21 @@ You'll need an API key from one of the supported AI providers:
 ### Step 1: Download and Initial Configuration
 
 1. In a terminal, navigate to the location where you want the `docker-compose.yml` and `.env` file to be.
-1. Download these two files:
+2. Download these two files:
    - [docker-compose.yml](https://github.com/rekwai/rekwai/raw/main/docker/docker-compose.yml)
    - [.env.example](https://github.com/rekwai/rekwai/raw/main/docker/.env.example)
-1. Rename `.env.example` to `.env` and open it in a text editor
-1. **Generate storage secrets** by running these commands (this expects you have openssl installed). It will append the
-generated secrets at the end of the `.env` file. **Note: only execute this once, the secrets need to remain the same in
-order for the services to function after restarting.**
+3. Rename `.env.example` to `.env` and open it in a text editor
+4. **Generate storage secrets** by running these commands (this expects you have openssl installed). It will append the
+   generated secrets at the end of the `.env` file. **Note: only execute this once, the secrets need to remain the same in
+   order for the services to function after restarting.**
    ```
    echo "S3_ACCESS_KEY_ID=GK$(openssl rand -hex 12)" >> .env
    echo "S3_SECRET_ACCESS_KEY=$(openssl rand -hex 32)" >> .env
    echo "GARAGE_RPC_SECRET=$(openssl rand -hex 32)" >> .env
-   echo "GARAGE_ADMIN_TOKEN=$(openssl rand -base64 32)" >> .env
+   echo "GARAGE_ADMIN_TOKEN=$(openssl rand -hex 32)" >> .env
    echo "GARAGE_METRICS_TOKEN=$(openssl rand -base64 32)" >> .env
    ```
-1. **Configure your AI provider:**
+5. **Configure your AI provider:**
    - Set `SELECTED_PROVIDER` to your chosen provider (`openai`, `gemini`, `anthropic`, or `openrouter`)
    - Fill in the API key for that provider
    - Configure the model settings (see below)


### PR DESCRIPTION
## Summary
- Add `name: rekwai-dev` to `docker/docker-compose.dev.yml`
- Add `name: rekwai` to `docker/docker-compose.yml`

Containers were named `docker-frontend-1` etc. because Docker Compose defaults the project name to the parent directory (`docker/`). Now they'll be `rekwai-dev-frontend-1` and `rekwai-backend-1` respectively.

Closes #37

## Test plan
- [ ] Run `docker compose -f docker/docker-compose.dev.yml up --build` and verify containers are prefixed with `rekwai-dev`
- [ ] Run `docker compose -f docker/docker-compose.yml config` and verify `name: rekwai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)